### PR TITLE
Improve setup script with package manager detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This project builds a fully automated offensive, defensive and hybrid (purple te
 
 ## 🚀 Quick Start
 
+Supported on Debian/Ubuntu, Fedora and Arch systems.
+
 1. **Download and extract**
    ```bash
    unzip cyberLab.zip

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,20 +2,48 @@
 
 set -e
 
-echo "[*] Updating system packages..."
-sudo apt update && sudo apt install -y \
-    vagrant \
-    virtualbox \
-    virtualbox-ext-pack \
-    ansible \
-    packer \
-    unzip \
-    git \
-    curl \
-    wget \
-    python3-pip \
-    libvirt-daemon-system \
+packages=(
+    vagrant
+    virtualbox
+    virtualbox-ext-pack
+    ansible
+    packer
+    unzip
+    git
+    curl
+    wget
+    python3-pip
+    libvirt-daemon-system
     qemu-kvm
+)
+
+echo "[*] Detecting package manager..."
+if command -v apt >/dev/null 2>&1; then
+    PM="apt"
+elif command -v dnf >/dev/null 2>&1; then
+    PM="dnf"
+elif command -v yum >/dev/null 2>&1; then
+    PM="yum"
+elif command -v pacman >/dev/null 2>&1; then
+    PM="pacman"
+else
+    echo "Unsupported distribution. Please install dependencies manually." >&2
+    exit 1
+fi
+
+echo "[*] Updating system packages and installing dependencies using $PM..."
+case "$PM" in
+    apt)
+        sudo apt update
+        sudo apt install -y "${packages[@]}"
+        ;;
+    dnf|yum)
+        sudo "$PM" install -y "${packages[@]}"
+        ;;
+    pacman)
+        sudo pacman -Sy --noconfirm "${packages[@]}"
+        ;;
+esac
 
 echo "[*] Installing required Vagrant plugins..."
 vagrant plugin install vagrant-winrm vagrant-winrm-syncedfolders


### PR DESCRIPTION
## Summary
- detect apt/dnf/yum/pacman in `scripts/setup.sh`
- install dependencies using detected package manager
- document supported distributions in the quick start guide

## Testing
- `scripts/run-tests.sh` *(fails: `podman` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b1c151e883249b8f2a2c71cd468b