### PR TITLE
Clean up Packer usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This project builds a fully automated offensive, defensive and hybrid (purple te
    chmod +x scripts/setup.sh
    ./scripts/setup.sh
    ```
-   This installs dependencies and builds Metasploitable 3 boxes automatically.
+   This installs all required dependencies.
 3. **Launch the lab**
    ```bash
    chmod +x scripts/launcher.sh
@@ -50,7 +50,7 @@ This project builds a fully automated offensive, defensive and hybrid (purple te
   - 32 GB RAM (64 GB recommended)
   - 8‑core CPU
   - 100+ GB free disk space
-- **Required packages:** `vagrant`, `virtualbox`, `ansible`, `packer`, `podman`, etc.
+- **Required packages:** `vagrant`, `virtualbox`, `ansible`, `podman`, etc.
 
 `setup.sh` installs all dependencies.
 
@@ -64,7 +64,7 @@ cyberLab/
 ├── podman/
 │   └── webapps/               # DVWA, Juice Shop + podman-compose.yml
 ├── scripts/
-│   ├── setup.sh               # Dependency installer + MSF3 box builder
+│   ├── setup.sh               # Dependency installer
 │   ├── launcher.sh            # Interactive launcher for lab components
 │   ├── teardown.sh            # Stops and removes all VMs + boxes
 │   └── update-hosts.sh        # Generates /etc/hosts entries for VMs
@@ -78,8 +78,8 @@ cyberLab/
 |-------------------------|-----------------------------|---------------------------|
 | kali                    | Red Team base               | Kali + Podman + Tools     |
 | metasploitable2         | Vulnerable Linux target     | Legacy VM                 |
-| metasploitable3-linux   | Advanced vuln Linux         | MSF3/Ansible              |
-| metasploitable3-windows | Windows target              | MSF3 + WinRM              |
+| metasploitable3-linux   | Advanced vuln Linux         | Ubuntu + Ansible              |
+| metasploitable3-windows | Windows target              | Windows 10 + WinRM              |
 | winserver               | Domain Controller + AD      | Windows Server + BadBlood |
 
 ## 🔒 License

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,7 +8,6 @@ sudo apt update && sudo apt install -y \
     virtualbox \
     virtualbox-ext-pack \
     ansible \
-    packer \
     unzip \
     git \
     curl \
@@ -20,31 +19,7 @@ sudo apt update && sudo apt install -y \
 echo "[*] Installing required Vagrant plugins..."
 vagrant plugin install vagrant-winrm vagrant-winrm-syncedfolders
 
-echo "[*] Cloning Metasploitable 3 repository..."
-if [ ! -d "metasploitable3" ]; then
-  git clone https://github.com/rapid7/metasploitable3.git
-  cd metasploitable3
-else
-  cd metasploitable3
-  git pull
-fi
 
-echo "[*] Installing Packer and Vagrant dependencies..."
-vagrant box list | grep "metasploitable3" || echo "No metasploitable3 boxes yet"
-
-echo "[*] Building Metasploitable 3 Linux box..."
-PACKER_BUILDER_TYPE=virtualbox-iso packer build windows_10.json
-
-echo "[*] Adding Metasploitable 3 Linux box to Vagrant..."
-vagrant box add metasploitable3-win windows_10_virtualbox.box --force
-
-echo "[*] Building Metasploitable 3 Ubuntu box..."
-PACKER_BUILDER_TYPE=virtualbox-iso packer build ubuntu1804.json
-
-echo "[*] Adding Metasploitable 3 Ubuntu box to Vagrant..."
-vagrant box add metasploitable3-linux ubuntu1804_virtualbox.box --force
-
-cd ..
 
 echo "[*] Setup complete. You can now run:"
 echo "    vagrant up"


### PR DESCRIPTION
## Summary
- remove unused Packer build steps from setup.sh
- update README to reflect use of generic boxes

## Testing
- `bash scripts/run-tests.sh` *(fails: podman/VMs not running)*

------
https://chatgpt.com/codex/tasks/task_e_6847b1c42d688324be40bb673c28d6b8